### PR TITLE
for webpack modules, first check if module is a directory with index.js in it

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -250,6 +250,7 @@ def find_import_module(module, project_path, webpack_modules, webpack_extensions
       folder_path = os.path.join(project_path, root)
 
       file = returnIfFile(os.path.join(folder_path, module)) \
+        or returnIfFile(os.path.join(folder_path, module, 'index' + extension)) \
         or returnIfFile(os.path.join(folder_path, module + extension)) \
         or returnIfFile(os.path.join(folder_path, 'index' + extension))
 

--- a/plugin.py
+++ b/plugin.py
@@ -252,7 +252,7 @@ def find_import_module(module, project_path, webpack_modules, webpack_extensions
       file = returnIfFile(os.path.join(folder_path, module)) \
         or returnIfFile(os.path.join(folder_path, module + extension)) \
         or returnIfFile(os.path.join(folder_path, module, 'index' + extension)) \
-        
+
       if file:
         return file
 

--- a/plugin.py
+++ b/plugin.py
@@ -250,10 +250,9 @@ def find_import_module(module, project_path, webpack_modules, webpack_extensions
       folder_path = os.path.join(project_path, root)
 
       file = returnIfFile(os.path.join(folder_path, module)) \
-        or returnIfFile(os.path.join(folder_path, module, 'index' + extension)) \
         or returnIfFile(os.path.join(folder_path, module + extension)) \
-        or returnIfFile(os.path.join(folder_path, 'index' + extension))
-
+        or returnIfFile(os.path.join(folder_path, module, 'index' + extension)) \
+        
       if file:
         return file
 

--- a/plugin.py
+++ b/plugin.py
@@ -251,7 +251,7 @@ def find_import_module(module, project_path, webpack_modules, webpack_extensions
 
       file = returnIfFile(os.path.join(folder_path, module)) \
         or returnIfFile(os.path.join(folder_path, module + extension)) \
-        or returnIfFile(os.path.join(folder_path, module, 'index' + extension)) \
+        or returnIfFile(os.path.join(folder_path, module, 'index' + extension))
 
       if file:
         return file


### PR DESCRIPTION
using below settings as in readme:
```
{
  "folders":
  [
    {
      "path": "."
    }
  ],
  "settings":
  {
     "webpack_resolve_modules": ["src", "other_module_directory"],
     "webpack_resolve_extensions": [".js", ".jsx", ".json"]
  }
}
```
and
```
src
|-my-folder
  |-index.js
|-index.js
|-file.js
```
```
// src/file.js
import something from 'my-folder'; // not working: incorrectly imports from 'src/index.js'
```
With above settings, import path should resolve to 'src/my-folder/index.js', but instead resolves to 'src/index.js'. This PR should fix this behavior.